### PR TITLE
Improve variant search query time

### DIFF
--- a/backend/spellbook/parsers/variants_query_parser.py
+++ b/backend/spellbook/parsers/variants_query_parser.py
@@ -436,4 +436,5 @@ def variants_query_parser(base: QuerySet, query_string: str) -> QuerySet:
             elif value.prefix != '':
                 raise NotSupportedError(f'Prefix {value.prefix} is not supported for {key} search.')
     queryset = smart_apply_filters(base, filters)
-    return queryset.distinct()
+    queryset = queryset.values('id').distinct()
+    return Variant.serialized_objects.filter(id__in=queryset)


### PR DESCRIPTION
This improves both the count query for pagination and the query itself when paginated for large amounts of results, by avoiding both sorting on the serialized column, and by deferring pulling out the serialized data until after the limiting is finished. It does this by doing the "work" in a subquery that then pulls out only the IDs, and then pulling out the serialized data mapped to these IDs afterward.