### PR TITLE
k8s: ipv6, tags, deregistration timeout

### DIFF
--- a/backend/.kubernetes/kubernetes.yaml
+++ b/backend/.kubernetes/kubernetes.yaml
@@ -153,7 +153,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ip-address-type: dualstack
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/tags: project=commanderspellbook,environment=prod
+    alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=60
     ## SSL Settings
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:083767677168:certificate/e6f5834f-bd9a-4333-962a-8fe0857e84ea


### PR DESCRIPTION
* Makes the load balancer dual stack to support IPv6
* Tags the load balancer with the project to aid in our cost tracking
* Reduces the deregistration_delay, which speeds up deployments

The idle timeout on the load balancer is 60 seconds. Currently if you have a request that exceeds 60 seconds the client will receive a 504 Gateway Timeout but the request _might_ continue running in the background and the response lost. This change will, during rollout, allow the container to be killed after 60 seconds instead of waiting 300 seconds.

These changes will not cause downtime and have already been applied on other SCM sites