### PR TITLE
Splitting kubernetes deployments into prod and dev

### DIFF
--- a/backend/.kubernetes/admin/dev/kustomization.yaml
+++ b/backend/.kubernetes/admin/dev/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../prod
+namespace: spellbook-dev
+patches:
+  - patch: |-
+      - op: replace
+        path: "/subjects/0/name"
+        value: "spellbook-admins-dev"
+    target:
+      kind: RoleBinding
+      name: spellbook-full-access-rolebinding

--- a/backend/.kubernetes/admin/prod/kubernetes.yaml
+++ b/backend/.kubernetes/admin/prod/kubernetes.yaml
@@ -1,0 +1,49 @@
+# After you apply this file, also create the IAM mapping for the roles. Example:
+#
+# eksctl create iamidentitymapping --cluster scm-main --region=us-east-2 \
+#     --arn arn:aws:iam::083767677168:role/spellbook-deploy-role \
+#     --username spellbook-deploy-role \
+#     --group spellbook-admins-prod \
+#     --no-duplicate-arns
+#
+# AND for the client role:
+#
+# eksctl create iamidentitymapping --cluster scm-main --region=us-east-2 \
+#     --arn arn:aws:iam::083767677168:role/spellbook-client-deploy-role \
+#     --username spellbook-client-deploy-role \
+#     --group spellbook-admins-prod \
+#     --no-duplicate-arns
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spellbook-ns-full-access
+  namespace: spellbook-prod
+rules:
+  - apiGroups: [""]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["extensions"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources: ["*"]
+    verbs: ["*"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spellbook-rolebinding
+  namespace: spellbook-prod
+subjects:
+  - kind: Group
+    name: spellbook-admins-prod
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: spellbook-ns-full-access
+  apiGroup: rbac.authorization.k8s.io

--- a/backend/.kubernetes/admin/prod/kubernetes.yaml
+++ b/backend/.kubernetes/admin/prod/kubernetes.yaml
@@ -14,6 +14,13 @@
 #     --group spellbook-admins-prod \
 #     --no-duplicate-arns
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spellbook-prod
+  labels:
+    elbv2.k8s.aws/pod-readiness-gate-inject: enabled
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/backend/.kubernetes/admin/prod/kustomization.yaml
+++ b/backend/.kubernetes/admin/prod/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- kubernetes.yaml

--- a/backend/.kubernetes/app/dev/kustomization.yaml
+++ b/backend/.kubernetes/app/dev/kustomization.yaml
@@ -18,8 +18,30 @@ patches:
 
   - patch: |-
       - op: replace
+        path: "/spec/template/spec/containers/0/resources/requests/memory"
+        value: "256M"
+    target:
+      kind: Deployment
+      name: spellbook-api
+
+  - patch: |-
+      - op: replace
         path: "/metadata/annotations/alb.ingress.kubernetes.io~1tags"
         value: "project=spellbook,environment=dev"
+    target:
+      kind: Ingress
+      name: spellbook-ingress
+  - patch: |-
+      - op: replace
+        path: "/spec/rules/0/host"
+        value: dev-backend.commanderspellbook.com
+    target:
+      kind: Ingress
+      name: spellbook-ingress
+  - patch: |-
+      - op: replace
+        path: "/spec/rules/1/host"
+        value: dev.commanderspellbook.com
     target:
       kind: Ingress
       name: spellbook-ingress

--- a/backend/.kubernetes/app/dev/kustomization.yaml
+++ b/backend/.kubernetes/app/dev/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../prod
+namespace: spellbook-dev
+images:
+  - name: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-prod-ecr
+    newName: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-dev-ecr
+    newTag: latest
+patches:
+  - patch: |-
+      - op: replace
+        path: "/spec/template/spec/containers/0/resources/requests/cpu"
+        value: "100m"
+    target:
+      kind: Deployment
+      name: spellbook-api
+
+  - patch: |-
+      - op: replace
+        path: "/metadata/annotations/alb.ingress.kubernetes.io~1tags"
+        value: "project=spellbook,environment=dev"
+    target:
+      kind: Ingress
+      name: spellbook-ingress

--- a/backend/.kubernetes/app/prod/kubernetes.yaml
+++ b/backend/.kubernetes/app/prod/kubernetes.yaml
@@ -1,11 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: spellbook
-  labels:
-    elbv2.k8s.aws/pod-readiness-gate-inject: enabled
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,6 +19,10 @@ spec:
       containers:
         - name: spellbook-api-app
           image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-prod-ecr
+          resources:
+            requests:
+              cpu: 256m
+              memory: 512M
           ports:
             - containerPort: 80
           readinessProbe:

--- a/backend/.kubernetes/app/prod/kubernetes.yaml
+++ b/backend/.kubernetes/app/prod/kubernetes.yaml
@@ -1,0 +1,239 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spellbook
+  labels:
+    elbv2.k8s.aws/pod-readiness-gate-inject: enabled
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: spellbook-prod
+  name: spellbook-api
+  labels:
+    app: spellbook-api
+spec:
+  selector:
+    matchLabels:
+      app: spellbook-api
+  template:
+    metadata:
+      labels:
+        app: spellbook-api
+    spec:
+      serviceAccountName: app-service-account
+      containers:
+        - name: spellbook-api-app
+          image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-prod-ecr
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+              - name: Host
+                value: commanderspellbook.com
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+              httpHeaders:
+              - name: Host
+                value: commanderspellbook.com
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 5
+          env:
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: django-secret
+            - name: KUBE_SQL_ENGINE
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: db-engine
+            - name: KUBE_SQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: db-name
+            - name: KUBE_SQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: db-user
+            - name: KUBE_SQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: db-password
+            - name: KUBE_SQL_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: db-host
+            - name: KUBE_SQL_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: db-port
+            - name: AWS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: aws-s3-bucket
+            - name: THIS_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: DISCORD_CLIENTID
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: discord-client-id
+            - name: DISCORD_CLIENTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: discord-client-secret
+            - name: DISCORD_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: discord-webhook-url
+            - name: MOXFIELD_USER_AGENT
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: moxfield-user-agent
+---
+# Autoscaling of the api pods
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: spellbook-api-autoscaler
+  namespace: spellbook-prod
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: spellbook-api
+  minReplicas: 3
+  maxReplicas: 36
+  targetCPUUtilizationPercentage: 80
+
+---
+# API Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: spellbook-api-service
+  namespace: spellbook-prod
+  labels:
+    app: spellbook-api
+    tier: web
+spec:
+  type: NodePort
+  selector:
+    app: spellbook-api
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+# Ingress Load Balancer
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: spellbook-ingress
+  namespace: spellbook-prod
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ip-address-type: dualstack
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/tags: project=commanderspellbook,environment=prod
+    alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=60
+    ## SSL Settings
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:083767677168:certificate/e6f5834f-bd9a-4333-962a-8fe0857e84ea
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+spec:
+  rules:
+    - host: backend.commanderspellbook.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: spellbook-api-service
+                port:
+                  number: 80
+    - host: commanderspellbook.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: spellbook-client-service
+                port:
+                  number: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-service-account
+  namespace: spellbook-prod
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::083767677168:role/spellbook-application-role
+---
+# Service Account for the Load Balancer Controller
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: aws-load-balancer-controller
+  name: aws-load-balancer-controller
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::083767677168:role/spellbook-loadbalancer-role
+---
+# Security group policy to allow pods to connect to RDS
+apiVersion: vpcresources.k8s.aws/v1beta1
+kind: SecurityGroupPolicy
+metadata:
+  name: spellbook-sg-policy
+spec:
+  serviceAccountSelector:
+    matchLabels:
+      role: backend
+  securityGroups:
+    groupIds:
+      - sg-010cc2542954759b3
+      - sg-08c982cb0b6242f63
+

--- a/backend/.kubernetes/app/prod/kustomization.yaml
+++ b/backend/.kubernetes/app/prod/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- kubernetes.yaml

--- a/backend/.kubernetes/discord-bot/kubernetes.yaml
+++ b/backend/.kubernetes/discord-bot/kubernetes.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: spellbook-discord-bot
+  name: spellbook-discord-bot
+  labels:
+    app: spellbook-discord-bot
+spec:
+  selector:
+    matchLabels:
+      app: spellbook-discord-bot
+  template:
+    metadata:
+      labels:
+        app: spellbook-discord-bot
+    spec:
+      serviceAccountName: app-service-account
+      containers:
+        - name: spellbook-discord-bot-app
+          image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-prod-discord-ecr
+          ports:
+            - containerPort: 80
+          livenessProbe:
+            exec:
+              command:
+                - curl
+                - -f
+                - https://backend.commanderspellbook.com
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 5
+          env:
+            - name: KUBE_DISCORD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: discord-bot-secrets
+                  key: discord-token
+            - name: KUBE_ADMIN_USER__0
+              valueFrom:
+                secretKeyRef:
+                  name: discord-bot-secrets
+                  key: deloo-discord-id
+            - name: KUBE_ADMIN_USER__1
+              valueFrom:
+                secretKeyRef:
+                  name: discord-bot-secrets
+                  key: andy-discord-id
+            - name: SPELLBOOK_API_URL
+              value: https://backend.commanderspellbook.com
+            - name: SPELLBOOK_WEBSITE_URL
+              value: https://commanderspellbook.com

--- a/backend/.kubernetes/jobs/dev/README.md
+++ b/backend/.kubernetes/jobs/dev/README.md
@@ -1,0 +1,3 @@
+# Dev Jobs
+
+Currently jobs only run with the production deployment. If we add jobs to the dev deployment, we would add a kustomization file in this directory.

--- a/backend/.kubernetes/jobs/prod/kubernetes.yaml
+++ b/backend/.kubernetes/jobs/prod/kubernetes.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: spellbook-update
-  namespace: spellbook
+  namespace: spellbook-prod
 spec:
   schedule: '0 * * * *'
   jobTemplate:

--- a/backend/.kubernetes/jobs/prod/kustomization.yaml
+++ b/backend/.kubernetes/jobs/prod/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- kubernetes.yaml

--- a/backend/.kubernetes/kubernetes.yaml
+++ b/backend/.kubernetes/kubernetes.yaml
@@ -1,327 +1,329 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: spellbook
-  labels:
-    elbv2.k8s.aws/pod-readiness-gate-inject: enabled
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  namespace: spellbook
-  name: spellbook-api
-  labels:
-    app: spellbook-api
-spec:
-  selector:
-    matchLabels:
-      app: spellbook-api
-  template:
-    metadata:
-      labels:
-        app: spellbook-api
-    spec:
-      serviceAccountName: app-service-account
-      containers:
-        - name: spellbook-api-app
-          image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-prod-ecr
-          ports:
-            - containerPort: 80
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 80
-              httpHeaders:
-              - name: Host
-                value: commanderspellbook.com
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
+# TODO - Delete this namespace and deployments after the prod namespace has been created and routed to
+
+# ---
+# apiVersion: v1
+# kind: Namespace
+# metadata:
+#   name: spellbook
+#   labels:
+#     elbv2.k8s.aws/pod-readiness-gate-inject: enabled
+# ---
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#   namespace: spellbook
+#   name: spellbook-api
+#   labels:
+#     app: spellbook-api
+# spec:
+#   selector:
+#     matchLabels:
+#       app: spellbook-api
+#   template:
+#     metadata:
+#       labels:
+#         app: spellbook-api
+#     spec:
+#       serviceAccountName: app-service-account
+#       containers:
+#         - name: spellbook-api-app
+#           image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-prod-ecr
+#           ports:
+#             - containerPort: 80
+#           readinessProbe:
+#             httpGet:
+#               path: /
+#               port: 80
+#               httpHeaders:
+#               - name: Host
+#                 value: commanderspellbook.com
+#             initialDelaySeconds: 30
+#             periodSeconds: 10
+#             timeoutSeconds: 5
             
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 80
-              httpHeaders:
-              - name: Host
-                value: commanderspellbook.com
-            initialDelaySeconds: 40
-            periodSeconds: 20
-            timeoutSeconds: 5
-          env:
-            - name: SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: django-secret
-            - name: KUBE_SQL_ENGINE
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: db-engine
-            - name: KUBE_SQL_DATABASE
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: db-name
-            - name: KUBE_SQL_USER
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: db-user
-            - name: KUBE_SQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: db-password
-            - name: KUBE_SQL_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: db-host
-            - name: KUBE_SQL_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: db-port
-            - name: AWS_S3_BUCKET
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: aws-s3-bucket
-            - name: THIS_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: DISCORD_CLIENTID
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: discord-client-id
-            - name: DISCORD_CLIENTSECRET
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: discord-client-secret
-            - name: DISCORD_WEBHOOK_URL
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: discord-webhook-url
-            - name: MOXFIELD_USER_AGENT
-              valueFrom:
-                secretKeyRef:
-                  name: api-secrets
-                  key: moxfield-user-agent
----
-# Autoscaling of the api pods
-apiVersion: autoscaling/v1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: spellbook-api-autoscaler
-  namespace: spellbook
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: spellbook-api
-  minReplicas: 3
-  maxReplicas: 36
-  targetCPUUtilizationPercentage: 80
+#           livenessProbe:
+#             httpGet:
+#               path: /
+#               port: 80
+#               httpHeaders:
+#               - name: Host
+#                 value: commanderspellbook.com
+#             initialDelaySeconds: 40
+#             periodSeconds: 20
+#             timeoutSeconds: 5
+#           env:
+#             - name: SECRET_KEY
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: django-secret
+#             - name: KUBE_SQL_ENGINE
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: db-engine
+#             - name: KUBE_SQL_DATABASE
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: db-name
+#             - name: KUBE_SQL_USER
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: db-user
+#             - name: KUBE_SQL_PASSWORD
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: db-password
+#             - name: KUBE_SQL_HOST
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: db-host
+#             - name: KUBE_SQL_PORT
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: db-port
+#             - name: AWS_S3_BUCKET
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: aws-s3-bucket
+#             - name: THIS_POD_IP
+#               valueFrom:
+#                 fieldRef:
+#                   fieldPath: status.podIP
+#             - name: DISCORD_CLIENTID
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: discord-client-id
+#             - name: DISCORD_CLIENTSECRET
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: discord-client-secret
+#             - name: DISCORD_WEBHOOK_URL
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: discord-webhook-url
+#             - name: MOXFIELD_USER_AGENT
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: api-secrets
+#                   key: moxfield-user-agent
+# ---
+# # Autoscaling of the api pods
+# apiVersion: autoscaling/v1
+# kind: HorizontalPodAutoscaler
+# metadata:
+#   name: spellbook-api-autoscaler
+#   namespace: spellbook
+# spec:
+#   scaleTargetRef:
+#     apiVersion: apps/v1
+#     kind: Deployment
+#     name: spellbook-api
+#   minReplicas: 3
+#   maxReplicas: 36
+#   targetCPUUtilizationPercentage: 80
 
----
-# API Service
-apiVersion: v1
-kind: Service
-metadata:
-  name: spellbook-api-service
-  namespace: spellbook
-  labels:
-    app: spellbook-api
-    tier: web
-spec:
-  type: NodePort
-  selector:
-    app: spellbook-api
-  ports:
-    - port: 80
-      targetPort: 80
+# ---
+# # API Service
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: spellbook-api-service
+#   namespace: spellbook
+#   labels:
+#     app: spellbook-api
+#     tier: web
+# spec:
+#   type: NodePort
+#   selector:
+#     app: spellbook-api
+#   ports:
+#     - port: 80
+#       targetPort: 80
 
----
-# Ingress Load Balancer
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: spellbook-ingress
-  namespace: spellbook
-  annotations:
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/ip-address-type: dualstack
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/tags: project=commanderspellbook,environment=prod
-    alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=60
-    ## SSL Settings
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
-    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:083767677168:certificate/e6f5834f-bd9a-4333-962a-8fe0857e84ea
-    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
-spec:
-  rules:
-    - host: backend.commanderspellbook.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: ssl-redirect
-                port:
-                  name: use-annotation
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: spellbook-api-service
-                port:
-                  number: 80
-    - host: commanderspellbook.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: ssl-redirect
-                port:
-                  name: use-annotation
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: spellbook-client-service
-                port:
-                  number: 80
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: app-service-account
-  namespace: spellbook
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::083767677168:role/spellbook-application-role
----
-# Service Account for the Load Balancer Controller
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/name: aws-load-balancer-controller
-  name: aws-load-balancer-controller
-  namespace: kube-system
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::083767677168:role/spellbook-loadbalancer-role
----
-# Security group policy to allow pods to connect to RDS
-apiVersion: vpcresources.k8s.aws/v1beta1
-kind: SecurityGroupPolicy
-metadata:
-  name: spellbook-sg-policy
-spec:
-  serviceAccountSelector:
-    matchLabels:
-      role: backend
-  securityGroups:
-    groupIds:
-      - sg-010cc2542954759b3
-      - sg-08c982cb0b6242f63
+# ---
+# # Ingress Load Balancer
+# apiVersion: networking.k8s.io/v1
+# kind: Ingress
+# metadata:
+#   name: spellbook-ingress
+#   namespace: spellbook
+#   annotations:
+#     kubernetes.io/ingress.class: alb
+#     alb.ingress.kubernetes.io/scheme: internet-facing
+#     alb.ingress.kubernetes.io/ip-address-type: dualstack
+#     alb.ingress.kubernetes.io/target-type: ip
+#     alb.ingress.kubernetes.io/tags: project=commanderspellbook,environment=prod
+#     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=60
+#     ## SSL Settings
+#     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
+#     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:083767677168:certificate/e6f5834f-bd9a-4333-962a-8fe0857e84ea
+#     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+# spec:
+#   rules:
+#     - host: backend.commanderspellbook.com
+#       http:
+#         paths:
+#           - path: /
+#             pathType: Prefix
+#             backend:
+#               service:
+#                 name: ssl-redirect
+#                 port:
+#                   name: use-annotation
+#           - path: /
+#             pathType: Prefix
+#             backend:
+#               service:
+#                 name: spellbook-api-service
+#                 port:
+#                   number: 80
+#     - host: commanderspellbook.com
+#       http:
+#         paths:
+#           - path: /
+#             pathType: Prefix
+#             backend:
+#               service:
+#                 name: ssl-redirect
+#                 port:
+#                   name: use-annotation
+#           - path: /
+#             pathType: Prefix
+#             backend:
+#               service:
+#                 name: spellbook-client-service
+#                 port:
+#                   number: 80
+# ---
+# apiVersion: v1
+# kind: ServiceAccount
+# metadata:
+#   name: app-service-account
+#   namespace: spellbook
+#   annotations:
+#     eks.amazonaws.com/role-arn: arn:aws:iam::083767677168:role/spellbook-application-role
+# ---
+# # Service Account for the Load Balancer Controller
+# apiVersion: v1
+# kind: ServiceAccount
+# metadata:
+#   labels:
+#     app.kubernetes.io/component: controller
+#     app.kubernetes.io/name: aws-load-balancer-controller
+#   name: aws-load-balancer-controller
+#   namespace: kube-system
+#   annotations:
+#     eks.amazonaws.com/role-arn: arn:aws:iam::083767677168:role/spellbook-loadbalancer-role
+# ---
+# # Security group policy to allow pods to connect to RDS
+# apiVersion: vpcresources.k8s.aws/v1beta1
+# kind: SecurityGroupPolicy
+# metadata:
+#   name: spellbook-sg-policy
+# spec:
+#   serviceAccountSelector:
+#     matchLabels:
+#       role: backend
+#   securityGroups:
+#     groupIds:
+#       - sg-010cc2542954759b3
+#       - sg-08c982cb0b6242f63
 
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: spellbook-ns-full-access
-  namespace: spellbook
-rules:
-  - apiGroups: [""]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["extensions"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["apps"]
-    resources: ["*"]
-    verbs: ["*"]
-  - apiGroups: ["batch"]
-    resources: ["*"]
-    verbs: ["*"]
+# ---
+# kind: Role
+# apiVersion: rbac.authorization.k8s.io/v1
+# metadata:
+#   name: spellbook-ns-full-access
+#   namespace: spellbook
+# rules:
+#   - apiGroups: [""]
+#     resources: ["*"]
+#     verbs: ["*"]
+#   - apiGroups: ["extensions"]
+#     resources: ["*"]
+#     verbs: ["*"]
+#   - apiGroups: ["apps"]
+#     resources: ["*"]
+#     verbs: ["*"]
+#   - apiGroups: ["batch"]
+#     resources: ["*"]
+#     verbs: ["*"]
 
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: spellbook-rolebinding
-  namespace: spellbook
-subjects:
-  - kind: Group
-    name: spellbook-admins
-    apiGroup: rbac.authorization.k8s.io
-roleRef:
-  kind: Role
-  name: spellbook-ns-full-access
-  apiGroup: rbac.authorization.k8s.io
+# ---
+# kind: RoleBinding
+# apiVersion: rbac.authorization.k8s.io/v1
+# metadata:
+#   name: spellbook-rolebinding
+#   namespace: spellbook
+# subjects:
+#   - kind: Group
+#     name: spellbook-admins
+#     apiGroup: rbac.authorization.k8s.io
+# roleRef:
+#   kind: Role
+#   name: spellbook-ns-full-access
+#   apiGroup: rbac.authorization.k8s.io
 
----
+# ---
 
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  namespace: spellbook
-  name: spellbook-discord-bot
-  labels:
-    app: spellbook-discord-bot
-spec:
-  selector:
-    matchLabels:
-      app: spellbook-discord-bot
-  template:
-    metadata:
-      labels:
-        app: spellbook-discord-bot
-    spec:
-      serviceAccountName: app-service-account
-      containers:
-        - name: spellbook-discord-bot-app
-          image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-prod-discord-ecr
-          ports:
-            - containerPort: 80
-          livenessProbe:
-            exec:
-              command:
-                - curl
-                - -f
-                - https://backend.commanderspellbook.com
-            initialDelaySeconds: 40
-            periodSeconds: 20
-            timeoutSeconds: 5
-          env:
-            - name: KUBE_DISCORD_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: discord-bot-secrets
-                  key: discord-token
-            - name: KUBE_ADMIN_USER__0
-              valueFrom:
-                secretKeyRef:
-                  name: discord-bot-secrets
-                  key: deloo-discord-id
-            - name: KUBE_ADMIN_USER__1
-              valueFrom:
-                secretKeyRef:
-                  name: discord-bot-secrets
-                  key: andy-discord-id
-            - name: SPELLBOOK_API_URL
-              value: https://backend.commanderspellbook.com
-            - name: SPELLBOOK_WEBSITE_URL
-              value: https://commanderspellbook.com
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#   namespace: spellbook
+#   name: spellbook-discord-bot
+#   labels:
+#     app: spellbook-discord-bot
+# spec:
+#   selector:
+#     matchLabels:
+#       app: spellbook-discord-bot
+#   template:
+#     metadata:
+#       labels:
+#         app: spellbook-discord-bot
+#     spec:
+#       serviceAccountName: app-service-account
+#       containers:
+#         - name: spellbook-discord-bot-app
+#           image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-prod-discord-ecr
+#           ports:
+#             - containerPort: 80
+#           livenessProbe:
+#             exec:
+#               command:
+#                 - curl
+#                 - -f
+#                 - https://backend.commanderspellbook.com
+#             initialDelaySeconds: 40
+#             periodSeconds: 20
+#             timeoutSeconds: 5
+#           env:
+#             - name: KUBE_DISCORD_TOKEN
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: discord-bot-secrets
+#                   key: discord-token
+#             - name: KUBE_ADMIN_USER__0
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: discord-bot-secrets
+#                   key: deloo-discord-id
+#             - name: KUBE_ADMIN_USER__1
+#               valueFrom:
+#                 secretKeyRef:
+#                   name: discord-bot-secrets
+#                   key: andy-discord-id
+#             - name: SPELLBOOK_API_URL
+#               value: https://backend.commanderspellbook.com
+#             - name: SPELLBOOK_WEBSITE_URL
+#               value: https://commanderspellbook.com

--- a/backend/.kubernetes/migration/dev/README.md
+++ b/backend/.kubernetes/migration/dev/README.md
@@ -1,0 +1,3 @@
+# Dev deployment
+
+Currently there is no separate database for the dev deployment, so there is no migration task for dev. If we add a dev database, then we will add the kustomization file for the migration task into this directory.

--- a/backend/.kubernetes/migration/kustomization.yaml
+++ b/backend/.kubernetes/migration/kustomization.yaml
@@ -1,2 +1,0 @@
-resources:
-- kube.migration.yaml

--- a/backend/.kubernetes/migration/prod/kubernetes.yaml
+++ b/backend/.kubernetes/migration/prod/kubernetes.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: spellbook-migration
-  namespace: spellbook
+  namespace: spellbook-prod
 spec:
   template:
     spec:

--- a/backend/.kubernetes/migration/prod/kustomization.yaml
+++ b/backend/.kubernetes/migration/prod/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- kubernetes.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+# Check if the number of arguments is correct
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 [environment]"
+    exit 1
+fi
+
+# Get the first CLI argument
+APP_ENVIRONMENT=$1
+
+ACCOUNT_ID='083767677168'
+REGION='us-east-2'
+ECR_REGISTRY=$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+CLUSTER_NAME=spellbook-prod-cluster
+IMAGE_TAG=$(git rev-parse HEAD)
+
+# Configure AWS credentials
+ROLE_ARN="arn:aws:iam::$ACCOUNT_ID:role/spellbook-deploy"
+
+# Function to configure the AWS CLI profile with a specific credential source
+# These profiles are separate because you cannot have both credential_source
+# and source_profile in the same profile, and it is not possible to clear either:
+# https://github.com/aws/aws-cli/issues/3346
+configure_profile_with_credential_source() {
+  local credential_source=$1
+
+  # Configure the profile with the specified credential source
+  aws configure set profile.$AWS_PROFILE.role_arn $ROLE_ARN
+  aws configure set profile.$AWS_PROFILE.credential_source $credential_source
+
+  echo "Configured profile $AWS_PROFILE with credential source: $credential_source"
+}
+
+# Function to configure the AWS CLI profile to use the default profile as source
+configure_profile_with_source_profile() {
+  local source_profile=$1
+
+  aws configure set profile.$AWS_PROFILE.role_arn $ROLE_ARN
+  aws configure set profile.$AWS_PROFILE.source_profile $source_profile
+
+  echo "Configured profile $AWS_PROFILE to use profile ${source_profile} as source"
+}
+
+# Function to test the AWS CLI profile by getting the caller identity
+aws_test_profile() {
+  if aws sts get-caller-identity > /dev/null 2>&1; then
+    echo "Successfully assumed role using profile $AWS_PROFILE with $1"
+    return 0
+  else
+    echo "Failed to assume role using profile $AWS_PROFILE with $1"
+    return 1
+  fi
+}
+
+aws_setup_profile() {
+  if [ -n "${AWS_PROFILE-}" ]; then
+    PARENT_AWS_PROFILE=$AWS_PROFILE
+    export AWS_PROFILE="spellbook-deploy-sp"
+    configure_profile_with_source_profile $PARENT_AWS_PROFILE
+    
+    if aws_test_profile "$PARENT_AWS_PROFILE"; then
+      return 0
+    fi
+  else
+    echo "AWS_PROFILE is not set. Not trying a parent profile."
+  fi
+
+  # Try different credential sources
+  export AWS_PROFILE="spellbook-deploy-cs"
+  CREDENTIAL_SOURCES=("Ec2InstanceMetadata" "Environment" "EcsContainer")
+  for credential_source in "${CREDENTIAL_SOURCES[@]}"; do
+    configure_profile_with_credential_source $credential_source
+    if aws_test_profile "credential source: $credential_source"; then
+      return 0
+    fi
+  done
+
+  # Attempt to use the default profile as a fallback
+  export AWS_PROFILE="spellbook-deploy-sp"
+  configure_profile_with_source_profile "default"
+  if aws_test_profile "default profile as source"; then
+    return 0
+  fi
+
+  echo "Failed to assume role with all specified credential sources and the default profile."
+  exit 1
+}
+
+do_migrations() {
+    echo "TODO: implement migrations for production environments..."
+    exit 1
+}
+
+aws_setup_profile
+
+# Login to Amazon ECR
+aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+
+## API
+docker build -f backend/Dockerfile --platform linux/amd64 . -t spellbook-backend:latest
+
+# Push image to Amazon ECR
+docker tag spellbook-backend:latest $ECR_REGISTRY/spellbook-$APP_ENVIRONMENT-ecr:$IMAGE_TAG
+docker tag spellbook-backend:latest $ECR_REGISTRY/spellbook-$APP_ENVIRONMENT-ecr:latest
+docker push --all-tags $ECR_REGISTRY/spellbook-$APP_ENVIRONMENT-ecr
+
+if $APP_ENVIRONMENT == "prod"; then
+    do_migrations
+else
+    echo "No migrations to run for non-prod environments."
+fi
+
+# Configure kubectl to connect to your cluster
+aws eks --region $REGION update-kubeconfig --name $CLUSTER_NAME
+
+# Apply Kubernetes configuration
+kubectl apply -k backend/.kubernetes/app/$APP_ENVIRONMENT/
+
+# Rollout pods
+kubectl rollout restart deployment/spellbook-api -n spellbook-$APP_ENVIRONMENT
+kubectl rollout status deployment/spellbook-api -n spellbook-$APP_ENVIRONMENT --timeout=600s


### PR DESCRIPTION
In order to split out deployments for production and development, production will need to be moved to a new namespace so that we can have separate namespaces for prod and dev. This PR splits all relevant kubernetes yaml into two directories with kustomization files for dev.