### PR TITLE
Add PostgreSQL statement timeout of 60 seconds

### DIFF
--- a/backend/backend/production_settings.py
+++ b/backend/backend/production_settings.py
@@ -55,6 +55,9 @@ CONN_MAX_AGE = 60 * 60
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 DATABASES = {
     'default': {
+        'OPTIONS': {
+            'options': '-c statement_timeout=60000'  # 60 seconds in milliseconds
+        },
         'ENGINE': os.getenv('KUBE_SQL_ENGINE', os.getenv('SQL_ENGINE', 'django.db.backends.sqlite3')),
         'NAME': os.getenv('KUBE_SQL_DATABASE', os.environ.get("SQL_DATABASE", os.path.join(BASE_DIR, "db.sqlite3"))),
         "USER": os.getenv('KUBE_SQL_USER', os.environ.get("SQL_USER", "user")),


### PR DESCRIPTION
Browsers and cloudfront time out after 60 seconds, so there's little point in spending database time longer than that to answer API queries.

Totally untested, made by AI but I think it's correct.