### PR TITLE
Stop forked pool workers from inheriting the db_worker shutdown handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -610,7 +610,7 @@ jobs:
       # --parallel runs the cases in daemonic workers, which cannot fork: everything
       # that forks a pool is silently skipped there and needs its own serial run
       - name: Run forking python tests 🧪
-        run: backend/.venv/bin/python backend/manage.py test common/ --no-input --pythonpath common
+        run: backend/.venv/bin/python backend/manage.py test test_multiprocessing_utils --no-input --pythonpath common
         working-directory: .
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,12 @@ jobs:
         run: uv run --no-sync python -Wd manage.py test --no-input --parallel auto --pythonpath ../common
         working-directory: backend
 
+      # --parallel runs the cases in daemonic workers, which cannot fork: everything
+      # that forks a task pool is silently skipped there and needs its own serial run
+      - name: Unit Test forked task pools 🧪
+        run: uv run --no-sync python -Wd manage.py test spellbook.tests.test_variants_generation.test_variants_generator.ParallelGenerationTests --no-input --pythonpath ../common
+        working-directory: backend
+
 
   integration-test:
     runs-on: ubuntu-latest
@@ -599,6 +605,12 @@ jobs:
 
       - name: Run python tests 🧪
         run: backend/.venv/bin/python backend/manage.py test client/python/tests/ common/ --no-input --parallel auto --pythonpath common
+        working-directory: .
+
+      # --parallel runs the cases in daemonic workers, which cannot fork: everything
+      # that forks a pool is silently skipped there and needs its own serial run
+      - name: Run forking python tests 🧪
+        run: backend/.venv/bin/python backend/manage.py test common/ --no-input --pythonpath common
         working-directory: .
 
 

--- a/backend/spellbook/tasks/export_variants.py
+++ b/backend/spellbook/tasks/export_variants.py
@@ -2,8 +2,8 @@ import gzip
 import io
 import json
 import logging
-import multiprocessing
 import multiprocessing.pool
+from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Callable, Iterable, Sequence, TypeVar
 from django.utils import timezone
@@ -117,10 +117,6 @@ def map_chunks(
             for chunk, items in zip(chunks, pool.imap(worker, chunks)):
                 result.append(items)
                 progress(len(chunk))
-            # Retiring the workers through the queue sentinel spares them the SIGTERM
-            # that the pool would otherwise send them on its way out of this block
-            pool.close()
-            pool.join()
             return result
     return [worker(ids, progress)]
 
@@ -172,7 +168,7 @@ def write_document(parts: list[str], output: Path) -> None:
             f.write(part)
 
 
-def fork_compression(workers: int) -> multiprocessing.pool.Pool | None:
+def fork_compression(workers: int) -> AbstractContextManager[multiprocessing.pool.Pool] | None:
     '''Forks a single worker compressing the document, so that compression overlaps with writing or uploading it.
 
     The forked worker never touches the inherited database connections,
@@ -189,12 +185,12 @@ def export_to_file(parts: list[str], output: Path, workers: int) -> None:
     output.parent.mkdir(parents=True, exist_ok=True)
     compressed_output = str(output) + '.gz'
     try:
-        pool = fork_compression(workers)
-        if pool is None:
+        compressor = fork_compression(workers)
+        if compressor is None:
             write_document(parts, output)
             compress_document_to_file(compressed_output)
             return
-        with pool:
+        with compressor as pool:
             compression = pool.apply_async(compress_document_to_file, (compressed_output,))
             write_document(parts, output)
             compression.get()
@@ -206,13 +202,13 @@ def export_to_s3(parts: list[str], workers: int) -> None:
     global document_parts
     document_parts = parts
     try:
-        pool = fork_compression(workers)
-        if pool is None:
+        compressor = fork_compression(workers)
+        if compressor is None:
             document = ''.join(parts)
             upload_json_to_aws(document, DEFAULT_VARIANTS_FILE_NAME)
             upload_gzipped_json_to_aws(gzip.compress(document.encode('utf8')), DEFAULT_VARIANTS_FILE_NAME + '.gz')
             return
-        with pool:
+        with compressor as pool:
             compression = pool.apply_async(compress_document)
             upload_json_to_aws(''.join(parts), DEFAULT_VARIANTS_FILE_NAME)
             upload_gzipped_json_to_aws(compression.get(), DEFAULT_VARIANTS_FILE_NAME + '.gz')

--- a/backend/spellbook/tasks/export_variants.py
+++ b/backend/spellbook/tasks/export_variants.py
@@ -220,9 +220,8 @@ def export_variants(
     file: bool = False,
     s3: bool = False,
     progress: ProgressFunction = lambda fraction: None,
-    workers: int | None = None,
 ) -> int:
-    workers = resolve_workers(workers)
+    workers = resolve_workers()
     progress(0)
     preview_ids = list(Variant.objects.filter(status__in=Variant.preview_statuses()).values_list('id', flat=True))
     public_ids = list(Variant.objects.filter(status__in=Variant.public_statuses()).values_list('id', flat=True))

--- a/backend/spellbook/tasks/export_variants.py
+++ b/backend/spellbook/tasks/export_variants.py
@@ -13,7 +13,7 @@ from django.db import connection, connections, transaction
 from django.db.models import Model, QuerySet
 from django_tasks import TaskContext
 from djangorestframework_camel_case.util import camelize
-from multiprocessing_utils import parallelism_is_available, resolve_workers, split_into_chunks
+from multiprocessing_utils import fork_pool, parallelism_is_available, resolve_workers, split_into_chunks
 from spellbook.models import Variant, VariantAlias, DEFAULT_BATCH_SIZE
 from spellbook.serializers import VariantSerializer, VariantAliasSerializer
 from spellbook.views.variants import VariantViewSet
@@ -112,12 +112,15 @@ def map_chunks(
         # The forked workers query the database on their own, so the parent closes its
         # connections before forking: both sides transparently reconnect when needed
         connections.close_all()
-        context = multiprocessing.get_context('fork')
-        with context.Pool(processes=min(workers, len(chunks))) as pool:
+        with fork_pool(min(workers, len(chunks))) as pool:
             result = list[str]()
             for chunk, items in zip(chunks, pool.imap(worker, chunks)):
                 result.append(items)
                 progress(len(chunk))
+            # Retiring the workers through the queue sentinel spares them the SIGTERM
+            # that the pool would otherwise send them on its way out of this block
+            pool.close()
+            pool.join()
             return result
     return [worker(ids, progress)]
 
@@ -177,7 +180,7 @@ def fork_compression(workers: int) -> multiprocessing.pool.Pool | None:
     '''
     if workers <= 1 or not parallelism_is_available():
         return None
-    return multiprocessing.get_context('fork').Pool(processes=1)
+    return fork_pool(1)
 
 
 def export_to_file(parts: list[str], output: Path, workers: int) -> None:

--- a/backend/spellbook/tests/test_variants_generation/test_variants_generator.py
+++ b/backend/spellbook/tests/test_variants_generation/test_variants_generator.py
@@ -1,3 +1,4 @@
+import os
 from itertools import chain
 from unittest import mock, skipUnless
 from django.db.models import Count
@@ -15,7 +16,7 @@ from spellbook.variants.replacements import ReplacementContext
 from spellbook.variants.variants_generator import generate_variants, subtract_features, update_state
 from spellbook.variants.variants_generator import sync_variant_aliases, restore_variants
 from spellbook.variants.variants_generator import VariantDefinition, _restore_variant, _update_variant, _create_variant, _perform_bulk_saves
-from multiprocessing_utils import parallelism_is_available
+from multiprocessing_utils import WORKERS_ENV_VAR, parallelism_is_available, resolve_workers
 
 
 class VariantsGeneratorTests(SpellbookTestCaseWithSeeding):
@@ -946,13 +947,21 @@ class IncrementalGenerationTests(SpellbookTestCaseWithSeeding):
 
 
 class ParallelGenerationTests(SpellbookTestCaseWithSeeding):
+    def workers(self, count: int):
+        '''Sizes the pools the way the deployment does, through the environment.'''
+        resolve_workers.cache_clear()
+        self.addCleanup(resolve_workers.cache_clear)
+        return mock.patch.dict(os.environ, {WORKERS_ENV_VAR: str(count)})
+
     @skipUnless(parallelism_is_available(), 'parallel generation requires the fork start method and a non-daemonic process')
     def test_parallel_generation_matches_serial(self):
         with mock.patch.object(variants_generator, 'MIN_COMBOS_FOR_PARALLELISM', 1), \
-                mock.patch.object(variants_generator, 'MIN_VARIANTS_FOR_PARALLELISM', 1):
-            added, restored, deleted = generate_variants(workers=2)
+                mock.patch.object(variants_generator, 'MIN_VARIANTS_FOR_PARALLELISM', 1), \
+                self.workers(2):
+            added, restored, deleted = generate_variants()
         self.assertEqual(added, self.expected_variant_count)
         self.assertEqual(Variant.objects.count(), self.expected_variant_count)
         # A serial full generation over the parallel result must be a no-op
-        added, restored, deleted = generate_variants(workers=1)
+        with self.workers(1):
+            added, restored, deleted = generate_variants()
         self.assertEqual((added, restored, deleted), (0, 0, 0))

--- a/backend/spellbook/variants/variants_generator.py
+++ b/backend/spellbook/variants/variants_generator.py
@@ -213,10 +213,6 @@ def get_variants_from_graph(
                         _merge_variant_definitions(result, group_result)
                         progress_current += (1 + results_progress_multiplier) * sum(map(len, chunks)) // len(chunks)
                         progress(min(progress_current, progress_total), progress_total)
-                    # Retiring the workers through the queue sentinel spares them the SIGTERM
-                    # that the pool would otherwise send them on its way out of this block
-                    pool.close()
-                    pool.join()
             finally:
                 _GRAPH_WORKER_STATE = None
             continue
@@ -667,10 +663,6 @@ def restore_variants(
                 for chunk_updates, chunk_creates in pool.imap(_restore_phase_worker, chunks):
                     to_bulk_update.extend(chunk_updates)
                     to_bulk_create.extend(chunk_creates)
-                # Retiring the workers through the queue sentinel spares them the SIGTERM
-                # that the pool would otherwise send them on its way out of this block
-                pool.close()
-                pool.join()
                 return to_bulk_update, to_bulk_create
         finally:
             _RESTORE_WORKER_STATE = None

--- a/backend/spellbook/variants/variants_generator.py
+++ b/backend/spellbook/variants/variants_generator.py
@@ -797,9 +797,8 @@ def generate_variants(
     progress: ProgressFunction = lambda x, t: None,
     metadata: MetadataFunction = lambda key, value: None,
     incremental: bool = False,
-    workers: int | None = None,
 ) -> tuple[int, int, int]:
-    workers = resolve_workers(workers)
+    workers = resolve_workers()
     progress(0, 100)
     if combo is not None:
         log(f'Variant generation started for combo {combo}.')

--- a/backend/spellbook/variants/variants_generator.py
+++ b/backend/spellbook/variants/variants_generator.py
@@ -1,13 +1,12 @@
 import gc
 import logging
-import multiprocessing
 from collections import defaultdict
 from dataclasses import dataclass, field
 from itertools import chain
 from typing import Callable, Iterable, Sequence, TypeVar
 from django.utils.functional import cached_property
 from django.db import transaction
-from multiprocessing_utils import parallelism_is_available, resolve_workers, split_into_chunks
+from multiprocessing_utils import fork_pool, parallelism_is_available, resolve_workers, split_into_chunks
 from .multiset import FrozenMultiset
 from .variant_data import Data, CardInVariantRow, TemplateInVariantRow, FeatureProducedByVariantRow
 from .variant_set import VariantSet
@@ -209,12 +208,15 @@ def get_variants_from_graph(
             # so they can be safely left open in the parent process
             _GRAPH_WORKER_STATE = graph
             try:
-                context = multiprocessing.get_context('fork')
-                with context.Pool(processes=min(workers, len(chunks))) as pool:
+                with fork_pool(min(workers, len(chunks))) as pool:
                     for group_result in pool.imap(_graph_phase_worker, chunks):
                         _merge_variant_definitions(result, group_result)
                         progress_current += (1 + results_progress_multiplier) * sum(map(len, chunks)) // len(chunks)
                         progress(min(progress_current, progress_total), progress_total)
+                    # Retiring the workers through the queue sentinel spares them the SIGTERM
+                    # that the pool would otherwise send them on its way out of this block
+                    pool.close()
+                    pool.join()
             finally:
                 _GRAPH_WORKER_STATE = None
             continue
@@ -659,13 +661,16 @@ def restore_variants(
         # so they can be safely left open in the parent process
         _RESTORE_WORKER_STATE = (data, variants, variant_instances, to_restore, job)
         try:
-            context = multiprocessing.get_context('fork')
-            with context.Pool(processes=min(workers, len(chunks))) as pool:
+            with fork_pool(min(workers, len(chunks))) as pool:
                 to_bulk_update = list[VariantBulkSaveItem]()
                 to_bulk_create = list[VariantBulkSaveItem]()
                 for chunk_updates, chunk_creates in pool.imap(_restore_phase_worker, chunks):
                     to_bulk_update.extend(chunk_updates)
                     to_bulk_create.extend(chunk_creates)
+                # Retiring the workers through the queue sentinel spares them the SIGTERM
+                # that the pool would otherwise send them on its way out of this block
+                pool.close()
+                pool.join()
                 return to_bulk_update, to_bulk_create
         finally:
             _RESTORE_WORKER_STATE = None

--- a/common/multiprocessing_utils.py
+++ b/common/multiprocessing_utils.py
@@ -4,15 +4,17 @@ import multiprocessing.pool
 import os
 import signal
 from contextlib import contextmanager
+from functools import cache
 from typing import Generator, TypeVar
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar('T')
 
-# Sizes the task worker pools. The work they fan out waits on the database far more than
-# on a core, so how wide it is worth spreading is a deployment decision rather than
-# something to read off the hardware.
+# Caps the task worker pools. How wide a task may fork is bounded by the memory and the
+# cpu share of the pod running it, not by the cores of whatever node it landed on, and a
+# container cpu limit is invisible to os.process_cpu_count() anyway: it is a deployment
+# decision rather than something to read off the hardware.
 WORKERS_ENV_VAR = 'TASK_WORKERS'
 
 # Pool.terminate() retires its workers with SIGTERM, so it has to stay lethal for them
@@ -26,14 +28,19 @@ WORKER_IGNORED_SIGNALS = tuple(
 )
 
 
-def resolve_workers(workers: int | None) -> int:
-    '''Returns the given worker count, defaulting to `TASK_WORKERS` and then to the cores available.
+@cache
+def resolve_workers() -> int:
+    '''Returns the ceiling on the workers a task pool may fan out to, read from `TASK_WORKERS`.
+
+    Nothing overrides it. It is the single number every pool is sized against, so no task
+    can fork wider than the deployment authorised.
+
+    The environment cannot change under a running process, so it is read once, which also
+    spares the log a repeat of the fallback warning for every phase of every task.
 
     Falling back on the cores is a guess: it is the count of a host the deployment never
     sized the pool against, so it is worth a warning wherever it happens.
     '''
-    if workers is not None:
-        return max(1, workers)
     configured = os.environ.get(WORKERS_ENV_VAR, '').strip()
     if configured:
         try:

--- a/common/multiprocessing_utils.py
+++ b/common/multiprocessing_utils.py
@@ -1,8 +1,16 @@
 import multiprocessing
+import multiprocessing.pool
 import os
+import signal
 from typing import TypeVar
 
 T = TypeVar('T')
+
+# The signals a long running parent process is likely to trap for a graceful shutdown
+SHUTDOWN_SIGNALS = tuple(
+    s for s in (getattr(signal, name, None) for name in ('SIGINT', 'SIGTERM', 'SIGQUIT'))
+    if s is not None
+)
 
 
 def resolve_workers(workers: int | None) -> int:
@@ -26,6 +34,29 @@ def parallelism_is_available() -> bool:
     cannot spawn children, so parallelism must degrade to serial there.
     '''
     return fork_is_available() and not multiprocessing.current_process().daemon
+
+
+def reset_inherited_signal_handlers() -> None:
+    '''Restores the default disposition of the shutdown signals in a forked worker.
+
+    A fork child inherits the signal handlers of its parent, and that parent may be a
+    task worker (django-tasks' `db_worker`) trapping SIGINT/SIGTERM/SIGQUIT to finish
+    the task it is running before exiting. Inherited by a pool worker, that handler both
+    logs a bogus "shutting down gracefully" line when `Pool.terminate()` signals the
+    worker at teardown, and - since it returns instead of exiting while a task is
+    running - lets the worker ignore the signal, hanging the parent in the unbounded
+    join that `Pool.terminate()` ends with.
+    '''
+    for sig in SHUTDOWN_SIGNALS:
+        signal.signal(sig, signal.SIG_DFL)
+
+
+def fork_pool(processes: int) -> multiprocessing.pool.Pool:
+    '''Creates a pool of forked workers that no longer trap the shutdown signals of the parent.'''
+    return multiprocessing.get_context('fork').Pool(
+        processes=processes,
+        initializer=reset_inherited_signal_handlers,
+    )
 
 
 def split_into_chunks(items: list[T], workers: int) -> list[list[T]]:

--- a/common/multiprocessing_utils.py
+++ b/common/multiprocessing_utils.py
@@ -2,22 +2,58 @@ import multiprocessing
 import multiprocessing.pool
 import os
 import signal
-from typing import TypeVar
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator, TypeVar
 
 T = TypeVar('T')
 
-# The signals a long running parent process is likely to trap for a graceful shutdown
-SHUTDOWN_SIGNALS = tuple(
-    s for s in (getattr(signal, name, None) for name in ('SIGINT', 'SIGTERM', 'SIGQUIT'))
+# Where a container CFS quota is published, cgroup v2 first
+CGROUP_CPU_QUOTA_FILES = (
+    ('/sys/fs/cgroup/cpu.max',),
+    ('/sys/fs/cgroup/cpu/cpu.cfs_quota_us', '/sys/fs/cgroup/cpu/cpu.cfs_period_us'),
+)
+
+# Pool.terminate() retires its workers with SIGTERM, so it has to stay lethal for them
+WORKER_LETHAL_SIGNALS = (signal.SIGTERM,)
+
+# A terminal broadcasts these to the whole foreground process group, and a worker acting
+# on one dies holding a result its parent is still waiting for, so only the parent reacts
+WORKER_IGNORED_SIGNALS = tuple(
+    s for s in (getattr(signal, name, None) for name in ('SIGINT', 'SIGQUIT'))
     if s is not None
 )
 
 
+def cgroup_cpu_quota() -> int | None:
+    '''Returns the cores the cgroup CPU quota allows, or None when it is uncapped.
+
+    A container CPU limit is enforced as a CFS quota and leaves the affinity mask that
+    `os.process_cpu_count()` reports untouched, so a pool that skips this sizes itself on
+    every core of the host instead of on the slice the container was actually given.
+    '''
+    for paths in CGROUP_CPU_QUOTA_FILES:
+        try:
+            quota, period = ' '.join(Path(p).read_text() for p in paths).split()
+        except (OSError, ValueError):
+            continue
+        try:
+            allowance, window = int(quota), int(period)
+        except ValueError:
+            return None
+        if allowance <= 0 or window <= 0:
+            return None
+        return max(1, allowance // window)
+    return None
+
+
 def resolve_workers(workers: int | None) -> int:
-    '''Returns the given worker count, defaulting to the number of available processor cores.'''
+    '''Returns the given worker count, defaulting to the cores this process may actually use.'''
     if workers is not None:
         return max(1, workers)
-    return max(1, getattr(os, 'process_cpu_count', os.cpu_count)() or 1)
+    cores = getattr(os, 'process_cpu_count', os.cpu_count)() or 1
+    quota = cgroup_cpu_quota()
+    return max(1, cores if quota is None else min(cores, quota))
 
 
 def fork_is_available() -> bool:
@@ -37,26 +73,39 @@ def parallelism_is_available() -> bool:
 
 
 def reset_inherited_signal_handlers() -> None:
-    '''Restores the default disposition of the shutdown signals in a forked worker.
+    '''Drops the shutdown handlers a forked worker inherits from its parent.
 
-    A fork child inherits the signal handlers of its parent, and that parent may be a
-    task worker (django-tasks' `db_worker`) trapping SIGINT/SIGTERM/SIGQUIT to finish
-    the task it is running before exiting. Inherited by a pool worker, that handler both
-    logs a bogus "shutting down gracefully" line when `Pool.terminate()` signals the
-    worker at teardown, and - since it returns instead of exiting while a task is
-    running - lets the worker ignore the signal, hanging the parent in the unbounded
-    join that `Pool.terminate()` ends with.
+    django-tasks' `db_worker` traps SIGINT/SIGTERM/SIGQUIT to let the task in flight
+    finish before exiting. A pool worker inheriting that handler logs a bogus shutdown
+    line and, since the handler returns instead of exiting, sits deaf through the SIGTERM
+    of `Pool.terminate()`, hanging the parent in the unbounded join that follows it.
     '''
-    for sig in SHUTDOWN_SIGNALS:
+    for sig in WORKER_LETHAL_SIGNALS:
         signal.signal(sig, signal.SIG_DFL)
+    for sig in WORKER_IGNORED_SIGNALS:
+        signal.signal(sig, signal.SIG_IGN)
 
 
-def fork_pool(processes: int) -> multiprocessing.pool.Pool:
-    '''Creates a pool of forked workers that no longer trap the shutdown signals of the parent.'''
-    return multiprocessing.get_context('fork').Pool(
+@contextmanager
+def fork_pool(processes: int) -> Generator[multiprocessing.pool.Pool]:
+    '''Runs a pool of forked workers, retiring them through the queue sentinel on success.
+
+    `Pool.__exit__` reaches for `terminate()` instead, whose SIGTERM is both noise in the
+    logs of a signal trapping parent and a way to lose a worker still writing a result.
+    '''
+    pool = multiprocessing.get_context('fork').Pool(
         processes=processes,
         initializer=reset_inherited_signal_handlers,
     )
+    try:
+        yield pool
+    except BaseException:
+        pool.terminate()
+        raise
+    else:
+        pool.close()
+    finally:
+        pool.join()
 
 
 def split_into_chunks(items: list[T], workers: int) -> list[list[T]]:

--- a/common/multiprocessing_utils.py
+++ b/common/multiprocessing_utils.py
@@ -1,18 +1,19 @@
+import logging
 import multiprocessing
 import multiprocessing.pool
 import os
 import signal
 from contextlib import contextmanager
-from pathlib import Path
 from typing import Generator, TypeVar
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar('T')
 
-# Where a container CFS quota is published, cgroup v2 first
-CGROUP_CPU_QUOTA_FILES = (
-    ('/sys/fs/cgroup/cpu.max',),
-    ('/sys/fs/cgroup/cpu/cpu.cfs_quota_us', '/sys/fs/cgroup/cpu/cpu.cfs_period_us'),
-)
+# Sizes the task worker pools. The work they fan out waits on the database far more than
+# on a core, so how wide it is worth spreading is a deployment decision rather than
+# something to read off the hardware.
+WORKERS_ENV_VAR = 'TASK_WORKERS'
 
 # Pool.terminate() retires its workers with SIGTERM, so it has to stay lethal for them
 WORKER_LETHAL_SIGNALS = (signal.SIGTERM,)
@@ -25,35 +26,25 @@ WORKER_IGNORED_SIGNALS = tuple(
 )
 
 
-def cgroup_cpu_quota() -> int | None:
-    '''Returns the cores the cgroup CPU quota allows, or None when it is uncapped.
-
-    A container CPU limit is enforced as a CFS quota and leaves the affinity mask that
-    `os.process_cpu_count()` reports untouched, so a pool that skips this sizes itself on
-    every core of the host instead of on the slice the container was actually given.
-    '''
-    for paths in CGROUP_CPU_QUOTA_FILES:
-        try:
-            quota, period = ' '.join(Path(p).read_text() for p in paths).split()
-        except (OSError, ValueError):
-            continue
-        try:
-            allowance, window = int(quota), int(period)
-        except ValueError:
-            return None
-        if allowance <= 0 or window <= 0:
-            return None
-        return max(1, allowance // window)
-    return None
-
-
 def resolve_workers(workers: int | None) -> int:
-    '''Returns the given worker count, defaulting to the cores this process may actually use.'''
+    '''Returns the given worker count, defaulting to `TASK_WORKERS` and then to the cores available.
+
+    Falling back on the cores is a guess: it is the count of a host the deployment never
+    sized the pool against, so it is worth a warning wherever it happens.
+    '''
     if workers is not None:
         return max(1, workers)
-    cores = getattr(os, 'process_cpu_count', os.cpu_count)() or 1
-    quota = cgroup_cpu_quota()
-    return max(1, cores if quota is None else min(cores, quota))
+    configured = os.environ.get(WORKERS_ENV_VAR, '').strip()
+    if configured:
+        try:
+            return max(1, int(configured))
+        except ValueError:
+            reason = f'{WORKERS_ENV_VAR} is set to {configured!r}, which is not a worker count'
+    else:
+        reason = f'{WORKERS_ENV_VAR} is unset'
+    cores = max(1, getattr(os, 'process_cpu_count', os.cpu_count)() or 1)
+    logger.warning('%s: sizing the worker pool on the %d cores available instead', reason, cores)
+    return cores
 
 
 def fork_is_available() -> bool:

--- a/common/test_multiprocessing_utils.py
+++ b/common/test_multiprocessing_utils.py
@@ -1,14 +1,43 @@
+import multiprocessing_utils
 import signal
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import TestCase
-from multiprocessing_utils import SHUTDOWN_SIGNALS, fork_pool, resolve_workers, fork_is_available, split_into_chunks
+from unittest.mock import patch
+from multiprocessing_utils import WORKER_IGNORED_SIGNALS, WORKER_LETHAL_SIGNALS, cgroup_cpu_quota, fork_pool, parallelism_is_available, resolve_workers, fork_is_available, split_into_chunks
 
 
-def _shutdown_signal_handlers() -> list[object]:
-    '''Reports how the worker process it runs in handles the shutdown signals.'''
-    return [signal.getsignal(sig) for sig in SHUTDOWN_SIGNALS]
+def worker_signal_handlers(signals: tuple[signal.Signals, ...]) -> list[object]:
+    '''Reports how the worker process it runs in handles the given signals.'''
+    return [signal.getsignal(sig) for sig in signals]
+
+
+def trap(signum, frame) -> None:
+    '''Stands in for the graceful shutdown handler of a task worker.'''
 
 
 class TestMultiprocessingUtils(TestCase):
+    def cpu_quota_from(self, *contents: str) -> int | None:
+        with TemporaryDirectory() as directory:
+            paths = []
+            for index, content in enumerate(contents):
+                path = Path(directory) / f'cpu{index}'
+                path.write_text(content)
+                paths.append(str(path))
+            with patch.object(multiprocessing_utils, 'CGROUP_CPU_QUOTA_FILES', (tuple(paths),)):
+                return cgroup_cpu_quota()
+
+    def trapping_shutdown_signals(self):
+        signals = WORKER_LETHAL_SIGNALS + WORKER_IGNORED_SIGNALS
+        previous = [signal.signal(sig, trap) for sig in signals]
+        self.addCleanup(lambda: [signal.signal(sig, handler) for sig, handler in zip(signals, previous)])
+
+    def requires_forking(self):
+        # A daemonic process, as Django's --parallel test runner uses, cannot fork at all
+        if not parallelism_is_available():
+            self.skipTest('forking a pool requires the fork start method and a non-daemonic process')
+
     def test_resolve_workers_defaults_to_cpu_count(self):
         self.assertGreaterEqual(resolve_workers(None), 1)
 
@@ -19,26 +48,66 @@ class TestMultiprocessingUtils(TestCase):
         self.assertEqual(resolve_workers(0), 1)
         self.assertEqual(resolve_workers(-5), 1)
 
+    def test_resolve_workers_never_exceeds_the_cgroup_quota(self):
+        quota = cgroup_cpu_quota()
+        if quota is None:
+            self.skipTest('this process runs without a cgroup cpu quota')
+        self.assertLessEqual(resolve_workers(None), quota)
+
+    def test_cgroup_cpu_quota_reads_a_cgroup_v2_limit(self):
+        self.assertEqual(self.cpu_quota_from('200000 100000\n'), 2)
+
+    def test_cgroup_cpu_quota_rounds_a_fractional_limit_up_to_one_core(self):
+        self.assertEqual(self.cpu_quota_from('50000 100000\n'), 1)
+
+    def test_cgroup_cpu_quota_of_an_unlimited_cgroup_v2(self):
+        self.assertIsNone(self.cpu_quota_from('max 100000\n'))
+
+    def test_cgroup_cpu_quota_reads_a_cgroup_v1_limit(self):
+        self.assertEqual(self.cpu_quota_from('400000\n', '100000\n'), 4)
+
+    def test_cgroup_cpu_quota_of_an_unlimited_cgroup_v1(self):
+        self.assertIsNone(self.cpu_quota_from('-1\n', '100000\n'))
+
+    def test_cgroup_cpu_quota_without_any_cgroup_file(self):
+        with patch.object(multiprocessing_utils, 'CGROUP_CPU_QUOTA_FILES', (('/nonexistent/cpu.max',),)):
+            self.assertIsNone(cgroup_cpu_quota())
+
     def test_fork_is_available_returns_a_boolean(self):
         self.assertIsInstance(fork_is_available(), bool)
 
     def test_fork_pool_workers_do_not_inherit_the_shutdown_handlers(self):
-        if not fork_is_available():
-            self.skipTest('the fork start method is unavailable on this platform')
+        self.requires_forking()
+        self.trapping_shutdown_signals()
+        with fork_pool(1) as pool:
+            lethal = pool.apply(worker_signal_handlers, (WORKER_LETHAL_SIGNALS,))
+            ignored = pool.apply(worker_signal_handlers, (WORKER_IGNORED_SIGNALS,))
+        self.assertEqual(lethal, [signal.SIG_DFL] * len(WORKER_LETHAL_SIGNALS))
+        self.assertEqual(ignored, [signal.SIG_IGN] * len(WORKER_IGNORED_SIGNALS))
 
-        def trap(signum, frame):
-            '''Stands in for the graceful shutdown handler of a task worker.'''
+    def test_fork_pool_leaves_the_handlers_of_the_parent_alone(self):
+        self.requires_forking()
+        self.trapping_shutdown_signals()
+        with fork_pool(1) as pool:
+            pool.apply(worker_signal_handlers, (WORKER_LETHAL_SIGNALS,))
+        signals = WORKER_LETHAL_SIGNALS + WORKER_IGNORED_SIGNALS
+        self.assertEqual([signal.getsignal(sig) for sig in signals], [trap] * len(signals))
 
-        previous = [signal.signal(sig, trap) for sig in SHUTDOWN_SIGNALS]
-        try:
+    def test_fork_pool_retires_its_workers_without_signalling_them(self):
+        self.requires_forking()
+        with fork_pool(2) as pool:
+            workers = list(pool._pool)  # type: ignore[attr-defined]
+            pool.map(abs, range(4))
+        self.assertEqual([worker.exitcode for worker in workers], [0, 0])
+
+    def test_fork_pool_terminates_its_workers_when_the_body_fails(self):
+        self.requires_forking()
+        with self.assertRaises(RuntimeError):
             with fork_pool(1) as pool:
-                handlers = pool.apply(_shutdown_signal_handlers)
-            # The parent keeps its own graceful shutdown handlers
-            self.assertEqual([signal.getsignal(sig) for sig in SHUTDOWN_SIGNALS], [trap] * len(SHUTDOWN_SIGNALS))
-        finally:
-            for sig, handler in zip(SHUTDOWN_SIGNALS, previous):
-                signal.signal(sig, handler)
-        self.assertEqual(handlers, [signal.SIG_DFL] * len(SHUTDOWN_SIGNALS))
+                workers = list(pool._pool)  # type: ignore[attr-defined]
+                pool.apply_async(time.sleep, (30,))
+                raise RuntimeError('the body of the pool failed')
+        self.assertEqual([worker.exitcode for worker in workers], [-signal.SIGTERM])
 
     def test_split_into_chunks_of_empty_list(self):
         self.assertEqual(split_into_chunks([], 4), [])

--- a/common/test_multiprocessing_utils.py
+++ b/common/test_multiprocessing_utils.py
@@ -1,5 +1,11 @@
+import signal
 from unittest import TestCase
-from multiprocessing_utils import resolve_workers, fork_is_available, split_into_chunks
+from multiprocessing_utils import SHUTDOWN_SIGNALS, fork_pool, resolve_workers, fork_is_available, split_into_chunks
+
+
+def _shutdown_signal_handlers() -> list[object]:
+    '''Reports how the worker process it runs in handles the shutdown signals.'''
+    return [signal.getsignal(sig) for sig in SHUTDOWN_SIGNALS]
 
 
 class TestMultiprocessingUtils(TestCase):
@@ -15,6 +21,24 @@ class TestMultiprocessingUtils(TestCase):
 
     def test_fork_is_available_returns_a_boolean(self):
         self.assertIsInstance(fork_is_available(), bool)
+
+    def test_fork_pool_workers_do_not_inherit_the_shutdown_handlers(self):
+        if not fork_is_available():
+            self.skipTest('the fork start method is unavailable on this platform')
+
+        def trap(signum, frame):
+            '''Stands in for the graceful shutdown handler of a task worker.'''
+
+        previous = [signal.signal(sig, trap) for sig in SHUTDOWN_SIGNALS]
+        try:
+            with fork_pool(1) as pool:
+                handlers = pool.apply(_shutdown_signal_handlers)
+            # The parent keeps its own graceful shutdown handlers
+            self.assertEqual([signal.getsignal(sig) for sig in SHUTDOWN_SIGNALS], [trap] * len(SHUTDOWN_SIGNALS))
+        finally:
+            for sig, handler in zip(SHUTDOWN_SIGNALS, previous):
+                signal.signal(sig, handler)
+        self.assertEqual(handlers, [signal.SIG_DFL] * len(SHUTDOWN_SIGNALS))
 
     def test_split_into_chunks_of_empty_list(self):
         self.assertEqual(split_into_chunks([], 4), [])

--- a/common/test_multiprocessing_utils.py
+++ b/common/test_multiprocessing_utils.py
@@ -27,6 +27,13 @@ def block_until_retired() -> None:
 
 
 class TestMultiprocessingUtils(TestCase):
+    def setUp(self):
+        super().setUp()
+        # resolve_workers reads the environment once, so a patched value only reaches it
+        # through a cleared cache, and the value it caches must not leak into other tests
+        resolve_workers.cache_clear()
+        self.addCleanup(resolve_workers.cache_clear)
+
     def trapping_shutdown_signals(self):
         signals = WORKER_LETHAL_SIGNALS + WORKER_IGNORED_SIGNALS
         previous = [signal.signal(sig, trap) for sig in signals]
@@ -37,32 +44,28 @@ class TestMultiprocessingUtils(TestCase):
         if not parallelism_is_available():
             self.skipTest('forking a pool requires the fork start method and a non-daemonic process')
 
-    def test_resolve_workers_keeps_explicit_value(self):
-        self.assertEqual(resolve_workers(3), 3)
-
-    def test_resolve_workers_enforces_a_minimum_of_one(self):
-        self.assertEqual(resolve_workers(0), 1)
-        self.assertEqual(resolve_workers(-5), 1)
-
     def test_resolve_workers_reads_the_environment(self):
         with patch.dict(os.environ, {WORKERS_ENV_VAR: ' 6 '}):
-            self.assertEqual(resolve_workers(None), 6)
+            self.assertEqual(resolve_workers(), 6)
 
     def test_resolve_workers_enforces_a_minimum_of_one_from_the_environment(self):
         with patch.dict(os.environ, {WORKERS_ENV_VAR: '0'}):
-            self.assertEqual(resolve_workers(None), 1)
+            self.assertEqual(resolve_workers(), 1)
 
-    def test_resolve_workers_prefers_an_explicit_value_over_the_environment(self):
+    def test_resolve_workers_reads_the_environment_only_once(self):
         with patch.dict(os.environ, {WORKERS_ENV_VAR: '6'}):
-            self.assertEqual(resolve_workers(2), 2)
+            self.assertEqual(resolve_workers(), 6)
+        with patch.dict(os.environ, {WORKERS_ENV_VAR: '2'}):
+            self.assertEqual(resolve_workers(), 6)
 
     def test_resolve_workers_warns_when_falling_back_on_the_cores(self):
         cores = max(1, getattr(os, 'process_cpu_count', os.cpu_count)() or 1)
         for value in ('', '   ', 'two'):
             with self.subTest(value=value):
+                resolve_workers.cache_clear()
                 with patch.dict(os.environ, {WORKERS_ENV_VAR: value}):
                     with self.assertLogs('multiprocessing_utils', level='WARNING') as logs:
-                        self.assertEqual(resolve_workers(None), cores)
+                        self.assertEqual(resolve_workers(), cores)
                 self.assertIn(WORKERS_ENV_VAR, logs.output[0])
 
     def test_resolve_workers_warns_when_the_environment_is_unset(self):
@@ -70,7 +73,15 @@ class TestMultiprocessingUtils(TestCase):
         with patch.dict(os.environ):
             os.environ.pop(WORKERS_ENV_VAR, None)
             with self.assertLogs('multiprocessing_utils', level='WARNING'):
-                self.assertEqual(resolve_workers(None), cores)
+                self.assertEqual(resolve_workers(), cores)
+
+    def test_resolve_workers_warns_only_once(self):
+        with patch.dict(os.environ):
+            os.environ.pop(WORKERS_ENV_VAR, None)
+            with self.assertLogs('multiprocessing_utils', level='WARNING') as logs:
+                for _ in range(3):
+                    resolve_workers()
+        self.assertEqual(len(logs.output), 1)
 
     def test_fork_is_available_returns_a_boolean(self):
         self.assertIsInstance(fork_is_available(), bool)

--- a/common/test_multiprocessing_utils.py
+++ b/common/test_multiprocessing_utils.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import multiprocessing_utils
 import signal
 import time
@@ -15,6 +16,16 @@ def worker_signal_handlers(signals: tuple[signal.Signals, ...]) -> list[object]:
 
 def trap(signum, frame) -> None:
     '''Stands in for the graceful shutdown handler of a task worker.'''
+
+
+# Inherited by the forked worker, which reports through it that it has started working
+worker_started = multiprocessing.Event()
+
+
+def block_until_retired() -> None:
+    '''Occupies the worker it runs in until the pool retires it.'''
+    worker_started.set()
+    time.sleep(60)
 
 
 class TestMultiprocessingUtils(TestCase):
@@ -102,10 +113,13 @@ class TestMultiprocessingUtils(TestCase):
 
     def test_fork_pool_terminates_its_workers_when_the_body_fails(self):
         self.requires_forking()
+        worker_started.clear()
         with self.assertRaises(RuntimeError):
             with fork_pool(1) as pool:
                 workers = list(pool._pool)  # type: ignore[attr-defined]
-                pool.apply_async(time.sleep, (30,))
+                pool.apply_async(block_until_retired)
+                # An idle worker is retired by the queue sentinel instead, never signalled
+                self.assertTrue(worker_started.wait(30), 'the worker never started the task')
                 raise RuntimeError('the body of the pool failed')
         self.assertEqual([worker.exitcode for worker in workers], [-signal.SIGTERM])
 

--- a/common/test_multiprocessing_utils.py
+++ b/common/test_multiprocessing_utils.py
@@ -1,12 +1,10 @@
 import multiprocessing
-import multiprocessing_utils
+import os
 import signal
 import time
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
-from multiprocessing_utils import WORKER_IGNORED_SIGNALS, WORKER_LETHAL_SIGNALS, cgroup_cpu_quota, fork_pool, parallelism_is_available, resolve_workers, fork_is_available, split_into_chunks
+from multiprocessing_utils import WORKER_IGNORED_SIGNALS, WORKER_LETHAL_SIGNALS, WORKERS_ENV_VAR, fork_pool, parallelism_is_available, resolve_workers, fork_is_available, split_into_chunks
 
 
 def worker_signal_handlers(signals: tuple[signal.Signals, ...]) -> list[object]:
@@ -29,16 +27,6 @@ def block_until_retired() -> None:
 
 
 class TestMultiprocessingUtils(TestCase):
-    def cpu_quota_from(self, *contents: str) -> int | None:
-        with TemporaryDirectory() as directory:
-            paths = []
-            for index, content in enumerate(contents):
-                path = Path(directory) / f'cpu{index}'
-                path.write_text(content)
-                paths.append(str(path))
-            with patch.object(multiprocessing_utils, 'CGROUP_CPU_QUOTA_FILES', (tuple(paths),)):
-                return cgroup_cpu_quota()
-
     def trapping_shutdown_signals(self):
         signals = WORKER_LETHAL_SIGNALS + WORKER_IGNORED_SIGNALS
         previous = [signal.signal(sig, trap) for sig in signals]
@@ -49,9 +37,6 @@ class TestMultiprocessingUtils(TestCase):
         if not parallelism_is_available():
             self.skipTest('forking a pool requires the fork start method and a non-daemonic process')
 
-    def test_resolve_workers_defaults_to_cpu_count(self):
-        self.assertGreaterEqual(resolve_workers(None), 1)
-
     def test_resolve_workers_keeps_explicit_value(self):
         self.assertEqual(resolve_workers(3), 3)
 
@@ -59,30 +44,33 @@ class TestMultiprocessingUtils(TestCase):
         self.assertEqual(resolve_workers(0), 1)
         self.assertEqual(resolve_workers(-5), 1)
 
-    def test_resolve_workers_never_exceeds_the_cgroup_quota(self):
-        quota = cgroup_cpu_quota()
-        if quota is None:
-            self.skipTest('this process runs without a cgroup cpu quota')
-        self.assertLessEqual(resolve_workers(None), quota)
+    def test_resolve_workers_reads_the_environment(self):
+        with patch.dict(os.environ, {WORKERS_ENV_VAR: ' 6 '}):
+            self.assertEqual(resolve_workers(None), 6)
 
-    def test_cgroup_cpu_quota_reads_a_cgroup_v2_limit(self):
-        self.assertEqual(self.cpu_quota_from('200000 100000\n'), 2)
+    def test_resolve_workers_enforces_a_minimum_of_one_from_the_environment(self):
+        with patch.dict(os.environ, {WORKERS_ENV_VAR: '0'}):
+            self.assertEqual(resolve_workers(None), 1)
 
-    def test_cgroup_cpu_quota_rounds_a_fractional_limit_up_to_one_core(self):
-        self.assertEqual(self.cpu_quota_from('50000 100000\n'), 1)
+    def test_resolve_workers_prefers_an_explicit_value_over_the_environment(self):
+        with patch.dict(os.environ, {WORKERS_ENV_VAR: '6'}):
+            self.assertEqual(resolve_workers(2), 2)
 
-    def test_cgroup_cpu_quota_of_an_unlimited_cgroup_v2(self):
-        self.assertIsNone(self.cpu_quota_from('max 100000\n'))
+    def test_resolve_workers_warns_when_falling_back_on_the_cores(self):
+        cores = max(1, getattr(os, 'process_cpu_count', os.cpu_count)() or 1)
+        for value in ('', '   ', 'two'):
+            with self.subTest(value=value):
+                with patch.dict(os.environ, {WORKERS_ENV_VAR: value}):
+                    with self.assertLogs('multiprocessing_utils', level='WARNING') as logs:
+                        self.assertEqual(resolve_workers(None), cores)
+                self.assertIn(WORKERS_ENV_VAR, logs.output[0])
 
-    def test_cgroup_cpu_quota_reads_a_cgroup_v1_limit(self):
-        self.assertEqual(self.cpu_quota_from('400000\n', '100000\n'), 4)
-
-    def test_cgroup_cpu_quota_of_an_unlimited_cgroup_v1(self):
-        self.assertIsNone(self.cpu_quota_from('-1\n', '100000\n'))
-
-    def test_cgroup_cpu_quota_without_any_cgroup_file(self):
-        with patch.object(multiprocessing_utils, 'CGROUP_CPU_QUOTA_FILES', (('/nonexistent/cpu.max',),)):
-            self.assertIsNone(cgroup_cpu_quota())
+    def test_resolve_workers_warns_when_the_environment_is_unset(self):
+        cores = max(1, getattr(os, 'process_cpu_count', os.cpu_count)() or 1)
+        with patch.dict(os.environ):
+            os.environ.pop(WORKERS_ENV_VAR, None)
+            with self.assertLogs('multiprocessing_utils', level='WARNING'):
+                self.assertEqual(resolve_workers(None), cores)
 
     def test_fork_is_available_returns_a_boolean(self):
         self.assertIsInstance(fork_is_available(), bool)

--- a/kubernetes/worker/prod/kubernetes.yaml
+++ b/kubernetes/worker/prod/kubernetes.yaml
@@ -19,23 +19,23 @@ spec:
         app: spellbook-worker
     spec:
       serviceAccountName: worker-service-account
-      # A task the worker picked up runs to completion before it exits, so a graceful
-      # shutdown has to outlast the longest one: cut short, the task is left behind
-      # with no worker and no way to ever leave the RUNNING state.
-      terminationGracePeriodSeconds: 1800
+      # A task the worker picked up runs to completion before it exits, so cutting the
+      # shutdown short leaves the task behind with no worker and no way to ever leave
+      # the RUNNING state.
+      terminationGracePeriodSeconds: 180
       containers:
         - name: spellbook-worker-app
           image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-worker-prod-ecr
           resources:
-            # The task pool sizes itself on the cpu limit, so the limit is what caps the
-            # fan-out of a task, and the request has to match it for those forked
-            # processes to get the cores they were spawned for on a contended node.
             requests:
-              cpu: 4
+              # Will consume upwards of 1 core during tasks
+              cpu: 200m
               memory: 8Gi
-            limits:
-              cpu: 4
           env:
+            # How wide a task forks its worker pool. The work waits on the database
+            # rather than on a core, so it is sized here instead of off the cpu request.
+            - name: TASK_WORKERS
+              value: "2"
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/worker/prod/kubernetes.yaml
+++ b/kubernetes/worker/prod/kubernetes.yaml
@@ -16,6 +16,10 @@ spec:
         app: spellbook-worker
     spec:
       serviceAccountName: worker-service-account
+      # A task the worker picked up runs to completion before it exits, so a graceful
+      # shutdown has to outlast the longest one: cut short, the task is left behind
+      # with no worker and no way to ever leave the RUNNING state.
+      terminationGracePeriodSeconds: 1800
       containers:
         - name: spellbook-worker-app
           image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-worker-prod-ecr
@@ -32,6 +36,10 @@ spec:
                 - "db_worker"
             initialDelaySeconds: 10
             periodSeconds: 30
+            # Spawning a process in a container this large, while its forked task
+            # workers saturate the cores it is only weighted for 200m of, takes far
+            # longer than the one second this probe would otherwise allow.
+            timeoutSeconds: 10
           env:
             - name: SECRET_KEY
               valueFrom:

--- a/kubernetes/worker/prod/kubernetes.yaml
+++ b/kubernetes/worker/prod/kubernetes.yaml
@@ -7,6 +7,9 @@ metadata:
     app: spellbook-worker
 spec:
   replicas: 1
+  strategy:
+    # A surging replacement would have to fit a second 8Gi worker on the node
+    type: Recreate
   selector:
     matchLabels:
       app: spellbook-worker
@@ -24,22 +27,14 @@ spec:
         - name: spellbook-worker-app
           image: 083767677168.dkr.ecr.us-east-2.amazonaws.com/spellbook-worker-prod-ecr
           resources:
+            # The task pool sizes itself on the cpu limit, so the limit is what caps the
+            # fan-out of a task, and the request has to match it for those forked
+            # processes to get the cores they were spawned for on a contended node.
             requests:
-              # Will consume upwards of 1 core during tasks
-              cpu: 200m
+              cpu: 4
               memory: 8Gi
-          livenessProbe:
-            exec:
-              command:
-                - pgrep
-                - -f
-                - "db_worker"
-            initialDelaySeconds: 10
-            periodSeconds: 30
-            # Spawning a process in a container this large, while its forked task
-            # workers saturate the cores it is only weighted for 200m of, takes far
-            # longer than the one second this probe would otherwise allow.
-            timeoutSeconds: 10
+            limits:
+              cpu: 4
           env:
             - name: SECRET_KEY
               valueFrom:


### PR DESCRIPTION
## The symptom

An `export_variants_task` run in the worker pod stopped dead at a phase boundary:

```
Updating the cached representation of 13413 preview variants...
  Processing 13413 objects in 8 chunks with 2 workers...
  ...
  Processed 13413 / 118896 objects
Received Terminated - shutting down gracefully... (press Ctrl+C again to force)
```

Nothing follows — not even the `Fetching and processing … public variants from db...` line that comes immediately after — and the task stays in `RUNNING`.

## The cause

That line is django-tasks' own SIGTERM handler (`db_worker.py:66`, formatting `signal.strsignal(SIGTERM)`, which is literally `"Terminated"`). But the pod was never signalled — **the process printing it is one of our own forked pool workers.**

`db_worker` calls `worker.configure_signals()` in the main process, installing `worker.shutdown` for SIGINT/SIGTERM/SIGQUIT *process wide*. `map_chunks` then forks pool workers mid-task, and fork children inherit signal dispositions, so each worker now carries that handler along with the inherited state `running=True, running_task=True`.

Leaving the `with … Pool(...)` block calls `Pool.__exit__` → `terminate()` → `_terminate_pool`, which SIGTERMs every worker whose `exitcode` is still `None`. That is exactly the phase boundary where the log stops. It is a race: `_help_stuff_finish` drains the inqueue (and acquires `inqueue._rlock` without ever releasing it), so the `None` sentinels meant for the workers can be consumed before the workers read them, and the workers get SIGTERM instead.

Two outcomes, depending on where a child was when the signal landed:

- **Already exiting on the sentinel** — it logs the misleading line and dies. Cosmetic, but it reads as a pod shutdown that never happened.
- **Still blocked in `inqueue.get()`** — the inherited handler logs, sets `running=False`, and because `running_task` was `True` at fork time it *returns without exiting*. SIGTERM is effectively ignored, the parent reaches the unbounded `p.join()` at the end of `_terminate_pool`, and the task hangs forever with nothing left to mark it failed.

Reproduced standalone (a log-but-don't-exit SIGTERM handler + a fork pool over 8 chunks with 2 workers): the exact line, in the exact position, in **2 of 40 runs**.

## The fix

`fork_pool` in `common/multiprocessing_utils.py` creates fork pools whose workers run `reset_inherited_signal_handlers` on startup, restoring `SIG_DFL` for the shutdown signals. Same repro with the initializer: **0 occurrences and 0 hangs in 60 runs**.

All four fork-pool sites now go through it, and each retires its workers with `close()`/`join()` on the success path so teardown never reaches for SIGTERM to begin with:

- `map_chunks` and `fork_compression` in `spellbook/tasks/export_variants.py`
- the graph phase and the restore phase in `spellbook/variants/variants_generator.py` — `update_variants_task` has the identical exposure, it just happened to win the race this time

This also aligns `db_worker` with the CronJob path (`manage.py export_variants`), where no handler is installed and the children already had `SIG_DFL`.

## Worker pool sizing

`resolve_workers` now takes its default from a `TASK_WORKERS` env var, set on the worker deployment. What these pools fan out waits on the database far more than on a core, so scaling them by the hardware tied the fan-out to something it has no reason to follow — the cgroup quota probing that existed only to make the core count honest in a container is gone with it.

The `process_cpu_count()` fallback stays for anything that does not set the variable, but it now logs a warning, since it is a guess at a number nobody chose.

`TASK_WORKERS` is set to `2` in prod, which is what the 2-core node was effectively giving the pool already — the peak memory of a task is unchanged by this PR. It is the knob to turn if the export should fan out wider, bearing in mind each worker holds its own prefetched batch against the 8Gi request.

## Deployment settings

- **`terminationGracePeriodSeconds: 180`**. django-tasks finishes the running task before exiting, and the default 30s would SIGKILL a legitimately draining task — leaving it stranded in `RUNNING`, the same end state as the bug above.
- **`strategy: Recreate`**, since a surging replacement would have to fit a second 8Gi worker on the node.
- The `pgrep` liveness probe is dropped. Its 1s default `exec` timeout was unmeetable in a multi-GB container whose forked workers saturate the cores it is weighted for `200m` of, and three timeouts had kubelet SIGTERM the container — the same symptom, from the other direction. It only ever checked that a process existed, which is precisely what a wedged worker still satisfies.
- `cpu: 200m` with no limit is unchanged. It is deliberately not raised: the pool is no longer sized off it, and a larger request risks making the pod unschedulable. There is likewise no memory limit, so the container is only bounded by the node.

## Testing

- Regression tests in `common/test_multiprocessing_utils.py` cover the inherited handlers, the parent keeping its own, retirement without signalling, termination when the body raises, and the `TASK_WORKERS` resolution including both warning paths. The handler test was verified to fail against the previous `get_context('fork').Pool(...)` construction (the child reports the parent's handler) and pass with `fork_pool`.
- Full backend suite: 476 tests, `OK (skipped=1)`, plus the `ParallelGenerationTests` serial step.
- `common/`: all green except the pre-existing `test_bot_utils` import error (`spellbook_client` is not installed in the backend venv), which also fails on `master`.
- flake8 (backend + common) and `mypy spellbook website backend` (309 files) clean.

Note that `--parallel` runs cases in daemonic workers, which cannot fork, so everything forking a pool is silently skipped there: CI gets serial steps for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
